### PR TITLE
Removed typed property to bring back PHP 7.3 compatibility

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    private string $alias;
+    private $alias;
 
     public function __construct(string $alias)
     {


### PR DESCRIPTION
Follow up to #1, covering @mnocon  [finding](https://github.com/ezsystems/JMSPaymentPaypalBundle/pull/1#pullrequestreview-817513951).